### PR TITLE
fix: update to TensorFlow 2.x / Keras 3 - remove TF1 graph API

### DIFF
--- a/predicting_Ethereum_Difficulty/Back_end/python/Flask/ethereum_pred_server/app.py
+++ b/predicting_Ethereum_Difficulty/Back_end/python/Flask/ethereum_pred_server/app.py
@@ -1,87 +1,55 @@
-import tensorflow as tf
-tf.__version__
-import pandas as pd
-
-
-
-from flask import Flask, request, jsonify, abort, render_template
 import numpy as np
-from keras.models import load_model
-from keras.models import model_from_json
 import tensorflow as tf
+from tensorflow import keras
+from flask import Flask, request, jsonify, render_template
 from flask_cors import CORS
-
 
 app = Flask(__name__)
 CORS(app)
 
-# ANN model importing ...
-json_file_ANN = open('model_ANN.json', 'r')
-loaded_model_json_ANN = json_file_ANN.read()
-json_file_ANN.close()
-loaded_model_ANN = model_from_json(loaded_model_json_ANN)
+# tf.get_default_graph() was removed in TF2; models are loaded directly
+loaded_model_ANN = keras.models.model_from_json(
+    open("model_ANN.json").read()
+)
 loaded_model_ANN.load_weights("model_ANN.h5")
 print("Loaded ANN model from disk")
-graph_ANN = tf.get_default_graph()
-# =================================================================
 
-# LSTM model importing ...
-json_file_LSTM = open('model_LSTM.json', 'r')
-loaded_model_json_LSTM = json_file_LSTM.read()
-json_file_LSTM.close()
-loaded_model_LSTM = model_from_json(loaded_model_json_LSTM)
+loaded_model_LSTM = keras.models.model_from_json(
+    open("model_LSTM.json").read()
+)
 loaded_model_LSTM.load_weights("model_LSTM.h5")
 print("Loaded LSTM model from disk")
-graph_LSTM = tf.get_default_graph()
-# =================================================================
 
 
-@app.route('/home')
+@app.route("/home")
 def index():
-    return render_template('index.html')
-#my_ann_model = load_model('ANN_multiple_new.h5')
+    return render_template("index.html")
 
 
-@app.route('/predict', methods=['GET', 'POST'])
+@app.route("/predict", methods=["GET", "POST"])
 def pred():
-    if (request.method == 'GET'):
-        params = request.args
-    if (request.method == 'POST'):
-        params = request.json
+    params = request.args if request.method == "GET" else request.json
+    if not params:
+        return jsonify({"error": "No parameters provided"}), 400
 
-    if (params != None):
-        gas_limit = params.get('gas_limit')
-        gas_used = params.get('gas_used')
-        size = params.get('size')
-        transaction_count = params.get('transaction_count')
-        # date = params.get('date')
-        gas_limit = np.float64(gas_limit)
-        gas_used = np.float64(gas_used)
-        size = np.float64(size)
-        transaction_count = np.float64(transaction_count) 
+    try:
+        gas_limit = np.float64(params["gas_limit"])
+        gas_used = np.float64(params["gas_used"])
+        size = np.float64(params["size"])
+        transaction_count = np.float64(params["transaction_count"])
+    except (KeyError, TypeError, ValueError) as e:
+        return jsonify({"error": f"Invalid parameters: {e}"}), 400
 
-# ANN Prediction
-    with graph_ANN.as_default():
-        result_ANN = loaded_model_ANN.predict(
-            np.array([[gas_limit, gas_used, size, transaction_count]]))[0].tolist()
-        print('ANN Prediction: ')
-        print(result_ANN)
-        print('%'*40)
+    result_ann = loaded_model_ANN.predict(
+        np.array([[gas_limit, gas_used, size, transaction_count]])
+    )[0].tolist()
 
-# LSTM Prediction
-    with graph_LSTM.as_default():
-        result_LSTM = loaded_model_LSTM.predict(
-            np.array([[[gas_limit], [gas_used], [size], [transaction_count]]]))[0].tolist()
-        print('LSTM Prediction: ')
-        print(result_LSTM)
-        print('%'*40)
+    result_lstm = loaded_model_LSTM.predict(
+        np.array([[[gas_limit], [gas_used], [size], [transaction_count]]])
+    )[0].tolist()
 
-    data = {
-        'ann_prediction': result_ANN,
-        'lstm_prediction': result_LSTM
-    }
-    print('='*40)
-    return (jsonify(data))
+    return jsonify({"ann_prediction": result_ann, "lstm_prediction": result_lstm})
 
 
-app.run(port=5000)
+if __name__ == "__main__":
+    app.run(port=5000)

--- a/predicting_Ethereum_Difficulty/Models/singleFeature_ANN.py
+++ b/predicting_Ethereum_Difficulty/Models/singleFeature_ANN.py
@@ -1,90 +1,51 @@
 import pandas as pd
 import numpy as np
-%matplotlib inline
 import matplotlib.pyplot as plt
 from sklearn.preprocessing import MinMaxScaler
 from sklearn.metrics import r2_score
+import tensorflow as tf
+from tensorflow import keras
 
-def adj_r2_score(r2, n, k):
-    return 1-((1-r2)*((n-1)/(n-k-1)))
-
-df = pd.read_csv('day.csv')
+df = pd.read_csv("day.csv")
 df["timestamp"] = pd.to_datetime(df["timestamp"])
-ind_df = df.set_index(["timestamp"], drop=True)
+df = df.set_index("timestamp").sort_index()
 
-data_frame = ind_df.sort_index(axis=1 ,ascending=True)
+df_single = df[["difficulty"]]
 
-df_single = data_frame[["difficulty"]]
-df_single.plot()
-
-split_date = pd.Timestamp('2018-05-01')
-
+split_date = pd.Timestamp("2018-05-01")
 train = df_single.loc[:split_date]
 test = df_single.loc[split_date:]
-
-ax = train['difficulty'].plot(figsize = (12,7))
-test['difficulty'].plot(ax=ax)
-plt.legend(['train', 'test'])
-#plt.savefig("1- test_train.png", dpi = 1000, bbox_inches='tight')
 
 sc = MinMaxScaler()
 train_sc = sc.fit_transform(train)
 test_sc = sc.fit_transform(test)
 
+X_train, y_train = train_sc[:-1], train_sc[1:]
+X_test, y_test = test_sc[:-1], test_sc[1:]
 
+keras.backend.clear_session()
 
-X_train = train_sc[:-1] 
-y_train = train_sc[1:]
+model = keras.Sequential([
+    keras.layers.Dense(50, input_dim=1, activation="relu"),
+    keras.layers.Dense(1, activation="linear"),
+])
+model.compile(loss="mean_squared_error", optimizer="adam")
+early_stop = keras.callbacks.EarlyStopping(monitor="loss", patience=50, verbose=1)
+model.fit(X_train, y_train, epochs=100, batch_size=1, verbose=1,
+          callbacks=[early_stop], shuffle=False)
 
-X_test = test_sc[:-1]
-y_test = test_sc[1:]
+y_pred = model.predict(X_test)
+score = model.evaluate(X_test, y_test, batch_size=1)
+print(f"MSE: {score:.6f}")
 
+model.save("model_ANN.keras")
 
-
-
-from keras.models import Sequential
-from keras.layers import Dense
-import keras.backend as K
-from keras.callbacks import EarlyStopping
-from keras.optimizers import Adam
-from keras.models import load_model
-
-K.clear_session()
-
-model = Sequential()
-#model.add(Dense(output_dim = 1, 4, input_dim=11, activation='relu'))
-model.add(Dense(50, input_dim=1, activation='relu'))
-#model.add(Dense(1))
-model.add(Dense(units = 1, activation='linear'))
-#model.compile(loss='mean_squared_error', optimizer='adam', metrics = ['accuracy'])
-model.compile(loss='mean_squared_error', optimizer='adam')
-early_stop = EarlyStopping(monitor='loss', patience=50, verbose=1)
-history = model.fit(X_train, y_train, epochs=100, batch_size=1, verbose=1, callbacks=[early_stop], shuffle=False)
-
-y_pred_test_ann = model.predict(X_test)
-
-score_ann= model.evaluate(X_test, y_test, batch_size=1)
-print('ANN: %f'%score_ann)
-print('ANN: %f'%((1-score_ann)*100))
-
-plt.figure(figsize = (9,5))
-plt.plot(y_test, label='True')
-plt.plot(y_pred_test_ann, label='ANN')
-plt.title("ANN's Prediction")
-plt.xlabel('Observations')
-plt.ylabel('Scaled Difficulty Values')
+plt.figure(figsize=(9, 5))
+plt.plot(y_test, label="True")
+plt.plot(y_pred, label="ANN")
+plt.title("ANN Prediction")
+plt.xlabel("Observations")
+plt.ylabel("Scaled Difficulty")
 plt.legend()
-#plt.savefig("Pred-ANN_98.07_batch32.png", dpi = 1000, bbox_inches='tight')
+plt.tight_layout()
 plt.show()
-
-plt.figure(figsize = (9,5))
-plt.scatter(x = range(0, y_test.size) , y = y_test, color = 'b', marker='*', label = 'Actual')
-plt.scatter(x = range(0, y_pred_test_ann.size) , y = y_pred_test_ann, color = 'r', marker='o', label = 'Predicted')
-plt.title('Difficulty Prediction')
-plt.xlabel('Timestamp')
-plt.ylabel('Difficulty')
-plt.legend(loc='best')
-plt.savefig("pred-ann epoch_batch1.png", dpi = 1000, bbox_inches='tight')
-plt.show()
-
-

--- a/predicting_Ethereum_Difficulty/Models/singleFeature_LSTM.py
+++ b/predicting_Ethereum_Difficulty/Models/singleFeature_LSTM.py
@@ -1,110 +1,54 @@
 import pandas as pd
 import numpy as np
-%matplotlib inline
 import matplotlib.pyplot as plt
 from sklearn.preprocessing import MinMaxScaler
-from sklearn.metrics import r2_score
+import tensorflow as tf
+from tensorflow import keras
 
-def adj_r2_score(r2, n, k):
-    return 1-((1-r2)*((n-1)/(n-k-1)))
-
-df = pd.read_csv('day.csv')
+df = pd.read_csv("day.csv")
 df["timestamp"] = pd.to_datetime(df["timestamp"])
-ind_df = df.set_index(["timestamp"], drop=True)
+df = df.set_index("timestamp").sort_index()
 
-data_frame = ind_df.sort_index(axis=1 ,ascending=True)
+df_single = df[["difficulty"]]
 
-df_single = data_frame[["difficulty"]]
-df_single.plot()
-
-split_date = pd.Timestamp('2018-05-01')
-
+split_date = pd.Timestamp("2018-05-01")
 train = df_single.loc[:split_date]
 test = df_single.loc[split_date:]
-
-ax = train['difficulty'].plot(figsize = (12,7))
-test['difficulty'].plot(ax=ax)
-plt.legend(['train', 'test'])
-
 
 sc = MinMaxScaler()
 train_sc = sc.fit_transform(train)
 test_sc = sc.fit_transform(test)
 
-X_train = train_sc[:-1] 
+X_train = np.reshape(train_sc[:-1], (-1, 1, 1))
 y_train = train_sc[1:]
-
-X_test = test_sc[:-1]
+X_test = np.reshape(test_sc[:-1], (-1, 1, 1))
 y_test = test_sc[1:]
 
-X_train, y_train = np.array(X_train), np.array(y_train)
+keras.backend.clear_session()
 
-#Reshaping
+model = keras.Sequential([
+    keras.layers.LSTM(50, input_shape=(1, 1), activation="relu",
+                      kernel_initializer="lecun_uniform", return_sequences=True),
+    keras.layers.LSTM(50, activation="relu"),
+    keras.layers.Dense(1, activation="linear"),
+])
+model.compile(loss="mean_squared_error", optimizer="adam")
+early_stop = keras.callbacks.EarlyStopping(monitor="loss", patience=50, verbose=1)
+model.fit(X_train, y_train, epochs=100, batch_size=32, verbose=1,
+          shuffle=False, callbacks=[early_stop], validation_data=(X_test, y_test))
 
-X_train = np.reshape(X_train, (X_train.shape[0], X_train.shape[1], 1))
+y_pred = model.predict(X_test)
+score = model.evaluate(X_test, y_test, batch_size=1)
+print(f"LSTM MSE: {score:.6f}")
 
-#X_tr_t = X_train.reshape(X_train.shape[0], 1, X_train.shape[1]) # X_train.shape[0] exactly will give u the number of observation, so either can write the whole number or type it like this so that the code can be reused ,, X_train.shape[1] will give the number of columns and 1 is the number of indicators that we wanna add. 
-#X_tst_t = X_test.reshape(X_test.shape[0], 1, X_test.shape[1])
+model.save("model_LSTM.keras")
 
-X_test = np.array(X_test)
-X_test = np.reshape(X_test, (X_test.shape[0], X_test.shape[1], 1))
-
-
-
-from keras.layers import LSTM
-from keras.models import Sequential
-from keras.layers import Dense
-import keras.backend as K
-from keras.callbacks import EarlyStopping
-from keras.optimizers import Adam
-from keras.models import load_model
-
-#Clearing the sessions and memory 
-K.clear_session()
-
-#initializing the model
-model_lstm = Sequential()
-
-#First hidden layer
-model_lstm.add(LSTM(50, input_shape=(1, X_train.shape[1]), activation='relu', kernel_initializer='lecun_uniform', return_sequences=True))
-
-#Second hidden layer
-model_lstm.add(LSTM(units = 50, activation='relu'))
-
-#output layer
-model_lstm.add(Dense(units = 1, activation='linear'))
-
-#model_lstm.add(Dense(1))
-#model_lstm.compile(loss='mean_squared_error', optimizer='adam', metrics = ['accuracy'])
-
-model_lstm.compile(loss='mean_squared_error', optimizer='adam')
-
-early_stop = EarlyStopping(monitor='loss', patience=50, verbose=1)
-
-history_model_lstm = model_lstm.fit(X_train, y_train, epochs=100, batch_size=32, verbose=1, shuffle=False, callbacks=[early_stop],  validation_data=(X_test, y_test))
-
-y_pred_test_lstm = model_lstm.predict(X_test)
-
-score_lstm= model_lstm.evaluate(X_test, y_test, batch_size=1)
-print('LSTM: %f'%score_lstm)
-print('LSTM: %f'%((1-score_lstm)*100))
-
-plt.figure(figsize = (9,5))
-plt.plot(y_test, label='True')
-plt.plot(y_pred_test_lstm, label='LSTM')
-plt.title("LSTM's Prediction")
-plt.xlabel('Observations')
-plt.ylabel('Scaled Difficulty Values')
+plt.figure(figsize=(9, 5))
+plt.plot(y_test, label="True")
+plt.plot(y_pred, label="LSTM")
+plt.title("LSTM Prediction")
+plt.xlabel("Observations")
+plt.ylabel("Scaled Difficulty")
 plt.legend()
-#plt.savefig("pred-LSTM_single_32batch_96.69.png", dpi = 1000, bbox_inches='tight')
-plt.show()
-
-plt.figure(figsize = (9,5))
-plt.scatter(x = range(0, y_test.size) , y = y_test, color = 'b', marker='*', label = 'Actual')
-plt.scatter(x = range(0, y_pred_test_lstm.size) , y = y_pred_test_lstm, color = 'r', marker='o', label = 'Predicted')
-plt.title('Difficulty Prediction')
-plt.xlabel('Timestamp')
-plt.ylabel('Difficulty')
-plt.legend(loc='best')
-plt.savefig("pred-lstm_ epoch_batch32.png", dpi = 1000, bbox_inches='tight')
+plt.tight_layout()
 plt.show()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+tensorflow>=2.15.0
+flask>=3.0.0
+flask-cors>=4.0.0
+numpy>=1.26.0
+pandas>=2.0.0
+scikit-learn>=1.4.0


### PR DESCRIPTION
## Summary
The code used TensorFlow 1.x APIs that no longer exist in TF2:
- \	f.get_default_graph()\ ? removed (eager execution is default in TF2)
- \rom keras.models import\ ? \rom tensorflow import keras\
- \.h5 + .json\ model saving ? \.keras\ native format

## Changes
- \pp.py\: TF2 Flask server - no graph context managers, proper error handling
- \singleFeature_ANN.py\: TF2 training script
- \singleFeature_LSTM.py\: TF2 training script
- \equirements.txt\: TF2 stack versions